### PR TITLE
Fix issue #5: Create a new GitHub Action workflow that runs `stack build`

### DIFF
--- a/.github/workflows/stack-build.yml
+++ b/.github/workflows/stack-build.yml
@@ -1,0 +1,22 @@
+name: Stack Build
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Haskell Stack
+        uses: haskell/actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: 'latest'
+
+      - name: Build
+        run: stack build


### PR DESCRIPTION
This pull request fixes #5.

The issue has been successfully resolved based on the following concrete changes:

1. A new GitHub Actions workflow file `.github/workflows/stack-build.yml` was created with the correct configuration to:
   - Trigger on both push and pull request events to all branches (`"*"`)
   - Run on Ubuntu latest
   - Use the official Haskell Stack setup action
   - Execute `stack build` command

2. The workflow includes all necessary components:
   - Proper YAML structure and indentation
   - Checkout action to get the repository code
   - Haskell Stack setup with latest version
   - The requested `stack build` command

3. The configuration directly addresses the requirements by:
   - Adding the GitHub action as requested
   - Implementing the `stack build` command
   - Setting up triggers for both push and pull requests

The changes made are complete and should result in a functioning CI workflow that builds the project using Stack whenever code is pushed or a pull request is created, which exactly matches the original request.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌